### PR TITLE
fix: correctly offset the epoch when configured

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,4 +3,12 @@ ruby = "4.0.0"
 rust = { version = "1.92.0", profile = "default" }
 
 [tasks]
-test = ["bundle exec rake", "bundle exec rake clobber"]
+test = [
+  "bundle exec rake clobber",
+  "bundle exec rake",
+]
+
+lint_rust = [
+  "cargo clippy --manifest-path ext/snowflaked/Cargo.toml -- -D warnings",
+  "cargo fmt --manifest-path ext/snowflaked/Cargo.toml --check",
+]

--- a/test/dummy/config/initializers/snowflaked.rb
+++ b/test/dummy/config/initializers/snowflaked.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Snowflaked.configure do |config|
+  # Set a custom epoch to verify correct offset calculation
+  config.epoch = Time.utc(2023, 1, 1)
+end

--- a/test/test_snowflaked.rb
+++ b/test/test_snowflaked.rb
@@ -92,4 +92,17 @@ class TestSnowflaked < ActiveSupport::TestCase
 
     assert_in_delta time_ms, reconstructed_ms, 1
   end
+
+  def test_custom_epoch_offsets_correctly
+    expected_epoch = Time.utc(2023, 1, 1)
+
+    assert_equal expected_epoch, Snowflaked.configuration.epoch, "Custom epoch was not loaded from initializer"
+
+    id = Snowflaked.id
+    timestamp = Snowflaked.timestamp(id)
+
+    # ensure the generated timestamp is current (within 5 seconds),
+    # proving that the custom epoch offset was handled correctly by both Generator and Parser.
+    assert_in_delta Time.now, timestamp, 5
+  end
 end


### PR DESCRIPTION
This PR fixes a bug that occurred when using a custom epoch, which produced incorrect timestamps, often placing generated IDs decades in the future. 