### PR TITLE
fix: performance improvements and consolidations

### DIFF
--- a/lib/snowflaked.rb
+++ b/lib/snowflaked.rb
@@ -29,8 +29,7 @@ module Snowflaked
     end
 
     def machine_id_value
-      id = @machine_id || default_machine_id
-      id % (MAX_MACHINE_ID + 1)
+      (@machine_id || default_machine_id) % (MAX_MACHINE_ID + 1)
     end
 
     def epoch_ms
@@ -46,8 +45,7 @@ module Snowflaked
     end
 
     def env_machine_id
-      id = ENV["SNOWFLAKED_MACHINE_ID"] || ENV.fetch("MACHINE_ID", nil)
-      id&.to_i
+      (ENV["SNOWFLAKED_MACHINE_ID"] || ENV.fetch("MACHINE_ID", nil))&.to_i
     end
 
     def hostname_pid_hash
@@ -79,8 +77,8 @@ module Snowflaked
 
     def timestamp(id)
       ensure_initialized!
-      time_ms = Native.timestamp_ms(id)
-      Time.at(time_ms / 1000, (time_ms % 1000) * 1000, :usec)
+      seconds, milliseconds = Native.timestamp_ms(id).divmod(1000)
+      Time.at(seconds, milliseconds * 1000, :usec)
     end
 
     def machine_id(id)
@@ -101,8 +99,7 @@ module Snowflaked
     def ensure_initialized!
       return if Native.initialized?
 
-      config = configuration
-      Native.init_generator(config.machine_id_value, config.epoch_ms)
+      Native.init_generator(configuration.machine_id_value, configuration.epoch_ms)
     end
   end
 end

--- a/lib/snowflaked.rb
+++ b/lib/snowflaked.rb
@@ -84,7 +84,6 @@ module Snowflaked
     end
 
     def machine_id(id)
-      ensure_initialized!
       Native.machine_id(id)
     end
 

--- a/lib/snowflaked.rb
+++ b/lib/snowflaked.rb
@@ -68,8 +68,8 @@ module Snowflaked
     end
 
     def id
-      ensure_initialized!
-      Native.generate
+      config = configuration
+      Native.generate(config.machine_id_value, config.epoch_ms)
     end
 
     def parse(id)
@@ -78,6 +78,7 @@ module Snowflaked
     end
 
     def timestamp(id)
+      ensure_initialized!
       time_ms = Native.timestamp_ms(id)
       Time.at(time_ms / 1000, (time_ms % 1000) * 1000, :usec)
     end
@@ -88,6 +89,7 @@ module Snowflaked
     end
 
     def timestamp_ms(id)
+      ensure_initialized!
       Native.timestamp_ms(id)
     end
 

--- a/lib/snowflaked/model_extensions.rb
+++ b/lib/snowflaked/model_extensions.rb
@@ -6,7 +6,7 @@ module Snowflaked
 
     included do
       class_attribute :_snowflake_attributes, instance_writer: false, default: [:id]
-      after_initialize :_generate_snowflake_ids, if: :new_record?
+      before_validation :_generate_snowflake_ids, on: :create
     end
 
     class_methods do

--- a/lib/snowflaked/model_extensions.rb
+++ b/lib/snowflaked/model_extensions.rb
@@ -20,11 +20,7 @@ module Snowflaked
       def _snowflake_columns_from_comments
         return @_snowflake_columns_from_comments if defined?(@_snowflake_columns_from_comments)
 
-        @_snowflake_columns_from_comments = if table_exists?
-          columns.filter_map { |col| col.name.to_sym if col.comment == Snowflaked::SchemaDefinitions::COMMENT }
-        else
-          []
-        end
+        @_snowflake_columns_from_comments = table_exists? ? columns.filter_map { |col| col.name.to_sym if col.comment == Snowflaked::SchemaDefinitions::COMMENT } : []
       end
 
       def _snowflake_attributes_with_columns
@@ -35,10 +31,10 @@ module Snowflaked
     private
 
     def _generate_snowflake_ids
-      attributes_to_generate = self.class._snowflake_attributes_with_columns
-      return if attributes_to_generate.empty?
+      attributes = self.class._snowflake_attributes_with_columns
+      return if attributes.empty?
 
-      attributes_to_generate.each do |attribute|
+      attributes.each do |attribute|
         next if self[attribute].present?
 
         self[attribute] = Snowflaked.id


### PR DESCRIPTION
Changes:


* `Snowflaked.id` now uses a single native call instead of doing a separate initialization check before generation.

* in the Rust extension, generate now follows a fast path:
  - if generator state is already initialized for the current PID, it generates immediately;
  - otherwise it initializes once (machine id + epoch) and generates in the same call.

* moved Snowflake assignment from `after_initialize` to `before_validation on: :create` (`after_initialize` runs on every model instantiation, including reads, which creates avoidable overhead on hot paths. `before_validation on: :create` keeps create-time behavior while removing read-time callback cost)

* `timestamp` and `timestamp_ms` now force initialization first, so custom epoch settings are honored even before the first generated ID.