### PR TITLE
fix: year 2093 overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,4 @@ dkms.conf
 # End of https://www.toptal.com/developers/gitignore/api/rust,ruby,rails,macos,visualstudiocode,linux,c++,c
 
 benchmarks/Gemfile.lock
+/docs/superpowers/plans

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ end
 ```ruby
 Snowflaked.configure do |config|
   config.machine_id = 42
-  config.epoch = Time.utc(1989, 1, 3) # When not configured, the epoch is set to the Unix epoch (January 1, 1970)
+  config.epoch = Time.utc(1989, 1, 3) # Defaults to DEFAULT_EPOCH (2024-01-01) if not configured
 end
 ```
 

--- a/lib/snowflaked.rb
+++ b/lib/snowflaked.rb
@@ -16,6 +16,7 @@ require_relative "snowflaked/railtie" if defined?(Rails::Railtie)
 
 module Snowflaked
   MAX_MACHINE_ID = 1023
+  DEFAULT_EPOCH = Time.utc(2024, 1, 1).freeze
 
   class Error < StandardError; end
   class ConfigurationError < Error; end
@@ -25,7 +26,7 @@ module Snowflaked
 
     def initialize
       @machine_id = nil
-      @epoch      = nil
+      @epoch      = DEFAULT_EPOCH
     end
 
     def machine_id_value

--- a/sig/snowflaked.rbs
+++ b/sig/snowflaked.rbs
@@ -1,6 +1,7 @@
 module Snowflaked
   VERSION: String
   MAX_MACHINE_ID: Integer
+  DEFAULT_EPOCH: Time
 
   class Error < StandardError
   end

--- a/test/test_snowflaked.rb
+++ b/test/test_snowflaked.rb
@@ -172,6 +172,17 @@ class TestSnowflaked < ActiveSupport::TestCase
     end
   end
 
+  def test_default_epoch_does_not_overflow_before_2093
+    config = Snowflaked::Configuration.new
+    epoch_ms = config.epoch_ms.to_i
+    max_snowflake_ms = (2**41) - 1
+    overflow_time = Time.at((epoch_ms + max_snowflake_ms) / 1000.0).utc
+
+    assert overflow_time.year >= 2093,
+      "Default epoch causes 41-bit timestamp overflow in #{overflow_time.year}. " \
+      "Set a default epoch of at least 2024-01-01 to push overflow to ~2093."
+  end
+
   private
 
   def fork_and_collect(&)

--- a/test/test_snowflaked.rb
+++ b/test/test_snowflaked.rb
@@ -172,15 +172,14 @@ class TestSnowflaked < ActiveSupport::TestCase
     end
   end
 
-  def test_default_epoch_does_not_overflow_before_2093
+  def test_default_epoch_does_not_overflow_before_2093 # rubocop:disable Naming/VariableNumber
     config = Snowflaked::Configuration.new
     epoch_ms = config.epoch_ms.to_i
     max_snowflake_ms = (2**41) - 1
     overflow_time = Time.at((epoch_ms + max_snowflake_ms) / 1000.0).utc
 
-    assert overflow_time.year >= 2093,
-      "Default epoch causes 41-bit timestamp overflow in #{overflow_time.year}. " \
-      "Set a default epoch of at least 2024-01-01 to push overflow to ~2093."
+    assert_operator overflow_time.year, :>=, 2093, "Default epoch causes 41-bit timestamp overflow in #{overflow_time.year}. " \
+                                                   "Set a default epoch of at least 2024-01-01 to push overflow to ~2093."
   end
 
   private


### PR DESCRIPTION
if epoch is not configured, epoch_ms returns nil, the Rust side receives None, and defaults to epoch_offset=0 (UNIX epoch, 1970). Snowflake's 41-bit timestamp field overflows in ~69 years from the epoch: 2039.

applications that never set a custom epoch are silently time-bombing. The test dummy sets it to 2023, but it's opt-in.