### PR TITLE
fix: Harden Snowflake generator state

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,12 @@ If `machine_id` is not explicitly configured, it resolves in this order:
 2. `MACHINE_ID` environment variable
 3. Auto-detected using the following formula: `(hostname.hash ^ pid) % 1024`
 
-For Kubernetes deployments, you can set the machine ID using an environment variable:
+For Kubernetes deployments, set the machine ID to a numeric value between `0` and `1023`:
 
 ```yaml
 env:
   - name: SNOWFLAKED_MACHINE_ID
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.name
+    value: "42"
 ```
 
 Or use a StatefulSet ordinal for guaranteed unique values:

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Snowflaked.configure do |config|
 end
 ```
 
+Configuration is locked after `Snowflaked.configure` or the first generated/parsed ID. Set it during application boot, before request threads start.
+
 ### Machine ID
 
 > [!TIP]
-> For multi-process servers like Puma, it is recommended to **not** configure `machine_id` explicitly. The gem automatically calculates a unique machine ID using `(hostname.hash ^ pid) % 1024`, which ensures each forked worker process gets a different ID and avoids duplicate Snowflake IDs.
+> For multi-process servers like Puma, it is recommended to **not** configure `machine_id` explicitly. The gem automatically calculates a process-local machine ID using `(hostname.hash ^ pid) % 1024`, so forked workers do not reuse the parent's cached machine ID.
 
 If you must set `machine_id` explicitly, use environment variables that differ per worker process.
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,8 @@ tl;dr: Snowflake IDs have a negligible performance impact compared to database-b
 
 ## Requirements
 
-- Ruby >= 3.2
-- rustc >= 1.81.0
-- cargo >= 1.81.0
+- Ruby >= 3.3
+- rustc / cargo >= 1.81.0 (development uses the toolchain pinned in `mise.toml`)
 - Mise
 
 ## Development

--- a/ext/snowflaked/src/lib.rs
+++ b/ext/snowflaked/src/lib.rs
@@ -113,6 +113,10 @@ fn configured_machine_id() -> Option<u16> {
     STATE.load().as_ref().filter(|s| s.init_pid == std::process::id()).map(|s| s.machine_id)
 }
 
+fn configured_epoch_ms() -> Option<u64> {
+    STATE.load().as_ref().filter(|s| s.init_pid == std::process::id()).map(|s| s.epoch_offset)
+}
+
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("Snowflaked")?;
@@ -126,6 +130,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     internal.define_singleton_method("sequence", function!(sequence, 1))?;
     internal.define_singleton_method("initialized?", function!(is_initialized, 0))?;
     internal.define_singleton_method("configured_machine_id", function!(configured_machine_id, 0))?;
+    internal.define_singleton_method("configured_epoch_ms", function!(configured_epoch_ms, 0))?;
 
     Ok(())
 }

--- a/ext/snowflaked/src/lib.rs
+++ b/ext/snowflaked/src/lib.rs
@@ -68,7 +68,10 @@ fn generate(ruby: &Ruby, machine_id: u16, epoch_ms: Option<u64>) -> Result<u64, 
     let (state, _) = ensure_state(machine_id, epoch_offset, std::process::id());
 
     validate_config(ruby, &state, machine_id, epoch_offset)?;
-    Ok(state.generator.generate())
+
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| state.generator.generate::<i64>()))
+        .map(|id| id as u64)
+        .map_err(|_| Error::new(ruby.exception_runtime_error(), "Snowflaked: system clock moved backwards; cannot generate a monotonic ID"))
 }
 
 fn epoch_offset(ruby: &Ruby) -> Result<u64, Error> {

--- a/ext/snowflaked/src/lib.rs
+++ b/ext/snowflaked/src/lib.rs
@@ -8,7 +8,6 @@ use std::time::UNIX_EPOCH;
 struct GeneratorState {
     generator: Generator,
     epoch_offset: u64,
-    machine_id: u16,
     init_pid: u32,
 }
 
@@ -29,11 +28,10 @@ fn ensure_state(machine_id: u16, epoch_offset: u64, current_pid: u32) -> (Arc<Ge
     let new_state = Arc::new(GeneratorState {
         generator: build_generator(machine_id, epoch_offset),
         epoch_offset,
-        machine_id,
         init_pid: current_pid,
     });
 
-    let prev_state = STATE.rcu(|current| {
+    STATE.rcu(|current| {
         if let Some(c) = current {
             if c.init_pid == current_pid {
                 return Arc::clone(c);
@@ -42,10 +40,10 @@ fn ensure_state(machine_id: u16, epoch_offset: u64, current_pid: u32) -> (Arc<Ge
         Arc::clone(&new_state)
     });
 
-    match prev_state.as_ref() {
-        Some(s) if s.init_pid == current_pid => (Arc::clone(s), false),
-        _ => (new_state, true),
-    }
+    let state = STATE.load_full().expect("generator state should be initialized");
+    let swapped = Arc::ptr_eq(&state, &new_state);
+
+    (state, swapped)
 }
 
 fn init_generator(machine_id: u16, epoch_ms: Option<u64>) -> bool {
@@ -53,21 +51,15 @@ fn init_generator(machine_id: u16, epoch_ms: Option<u64>) -> bool {
     swapped
 }
 
-fn validate_config(ruby: &Ruby, s: &GeneratorState, machine_id: u16, epoch_offset: u64) -> Result<(), Error> {
-    if s.machine_id != machine_id || s.epoch_offset != epoch_offset {
-        return Err(Error::new(
-            ruby.exception_runtime_error(),
-            "Generator already initialized with a different machine_id or epoch for this process",
-        ));
-    }
-    Ok(())
+fn current_state(ruby: &Ruby) -> Result<Arc<GeneratorState>, Error> {
+    STATE
+        .load_full()
+        .filter(|s| s.init_pid == std::process::id())
+        .ok_or_else(|| Error::new(ruby.exception_runtime_error(), "Generator not initialized"))
 }
 
-fn generate(ruby: &Ruby, machine_id: u16, epoch_ms: Option<u64>) -> Result<u64, Error> {
-    let epoch_offset = epoch_ms.unwrap_or(0);
-    let (state, _) = ensure_state(machine_id, epoch_offset, std::process::id());
-
-    validate_config(ruby, &state, machine_id, epoch_offset)?;
+fn generate(ruby: &Ruby) -> Result<u64, Error> {
+    let state = current_state(ruby)?;
 
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| state.generator.generate::<i64>()))
         .map(|id| id as u64)
@@ -75,11 +67,7 @@ fn generate(ruby: &Ruby, machine_id: u16, epoch_ms: Option<u64>) -> Result<u64, 
 }
 
 fn epoch_offset(ruby: &Ruby) -> Result<u64, Error> {
-    STATE
-        .load()
-        .as_ref()
-        .map(|s| s.epoch_offset)
-        .ok_or_else(|| Error::new(ruby.exception_runtime_error(), "Generator not initialized"))
+    current_state(ruby).map(|s| s.epoch_offset)
 }
 
 fn parse(ruby: &Ruby, id: u64) -> Result<RHash, Error> {
@@ -109,28 +97,18 @@ fn is_initialized() -> bool {
     STATE.load().as_ref().is_some_and(|s| s.init_pid == std::process::id())
 }
 
-fn configured_machine_id() -> Option<u16> {
-    STATE.load().as_ref().filter(|s| s.init_pid == std::process::id()).map(|s| s.machine_id)
-}
-
-fn configured_epoch_ms() -> Option<u64> {
-    STATE.load().as_ref().filter(|s| s.init_pid == std::process::id()).map(|s| s.epoch_offset)
-}
-
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("Snowflaked")?;
     let internal = module.define_module("Native")?;
 
     internal.define_singleton_method("init_generator", function!(init_generator, 2))?;
-    internal.define_singleton_method("generate", function!(generate, 2))?;
+    internal.define_singleton_method("generate", function!(generate, 0))?;
     internal.define_singleton_method("parse", function!(parse, 1))?;
     internal.define_singleton_method("timestamp_ms", function!(timestamp_ms, 1))?;
     internal.define_singleton_method("machine_id", function!(machine_id_from_id, 1))?;
     internal.define_singleton_method("sequence", function!(sequence, 1))?;
     internal.define_singleton_method("initialized?", function!(is_initialized, 0))?;
-    internal.define_singleton_method("configured_machine_id", function!(configured_machine_id, 0))?;
-    internal.define_singleton_method("configured_epoch_ms", function!(configured_epoch_ms, 0))?;
 
     Ok(())
 }

--- a/lib/snowflaked.rb
+++ b/lib/snowflaked.rb
@@ -22,35 +22,57 @@ module Snowflaked
   class ConfigurationError < Error; end
 
   class Configuration
-    attr_accessor :machine_id, :epoch
+    attr_reader :machine_id, :epoch
 
     def initialize
       @machine_id = nil
       @epoch      = DEFAULT_EPOCH
     end
 
+    def machine_id=(value)
+      @machine_id       = value
+      @machine_id_value = nil
+    end
+
+    def epoch=(value)
+      @epoch    = value
+      @epoch_ms = nil
+    end
+
     def machine_id_value
-      (@machine_id || default_machine_id) % (MAX_MACHINE_ID + 1)
+      return @machine_id_value if @machine_id_value && @machine_id_value_pid == Process.pid
+
+      @machine_id_value_pid = Process.pid
+      @machine_id_value     = resolve_machine_id
     end
 
     def epoch_ms
       return nil unless @epoch
 
-      (@epoch.to_r * 1000).to_i
+      @epoch_ms ||= (@epoch.to_r * 1000).to_i
     end
 
     private
 
-    def default_machine_id
-      env_machine_id || hostname_pid_hash
-    end
+    # Resolution order: explicit config, then env vars, then an auto fallback.
+    # Explicit and env values are range-checked; the fallback is always valid.
+    def resolve_machine_id
+      return checked_machine_id(@machine_id) if @machine_id
 
-    def env_machine_id
-      (ENV["SNOWFLAKED_MACHINE_ID"] || ENV.fetch("MACHINE_ID", nil))&.to_i
-    end
+      env = ENV["SNOWFLAKED_MACHINE_ID"] || ENV.fetch("MACHINE_ID", nil)
+      return checked_machine_id(env) if env
 
-    def hostname_pid_hash
+      # Unique-enough per process without coordination: varies by host and by
+      # pid, so forked workers each get a different id. % keeps it in range.
       (Socket.gethostname.hash ^ Process.pid) % (MAX_MACHINE_ID + 1)
+    end
+
+    # Coerce to Integer and ensure it fits in 0..MAX_MACHINE_ID, else raise.
+    def checked_machine_id(value)
+      id = Integer(value, exception: false)
+      return id if id&.between?(0, MAX_MACHINE_ID)
+
+      raise ConfigurationError, "machine_id must be an integer between 0 and #{MAX_MACHINE_ID}, got #{value.inspect}"
     end
   end
 
@@ -63,6 +85,16 @@ module Snowflaked
       yield(configuration) if block_given?
 
       ensure_initialized!
+
+      # The Rust generator is built once per process. If machine_id changed
+      # after the first ID was generated, Ruby and Rust would disagree, so
+      # fail loudly here instead of silently using the stale generator.
+      configured = Native.configured_machine_id
+      if configured && configured != configuration.machine_id_value
+        raise ConfigurationError,
+              "machine_id cannot be changed after the first ID is generated (currently #{configured})"
+      end
+
       configuration
     end
 
@@ -79,7 +111,12 @@ module Snowflaked
     def timestamp(id)
       ensure_initialized!
       seconds, milliseconds = Native.timestamp_ms(id).divmod(1000)
-      Time.zone.at(seconds, milliseconds * 1000, :usec)
+
+      if defined?(Time.zone) && Time.zone
+        Time.zone.at(seconds, milliseconds * 1000, :usec)
+      else
+        Time.at(seconds, milliseconds * 1000, :usec).utc
+      end
     end
 
     def machine_id(id) # rubocop:disable Rails/Delegate

--- a/lib/snowflaked.rb
+++ b/lib/snowflaked.rb
@@ -27,23 +27,35 @@ module Snowflaked
     def initialize
       @machine_id = nil
       @epoch      = DEFAULT_EPOCH
+      @sealed     = false
     end
 
     def machine_id=(value)
-      @machine_id       = value
-      @machine_id_value = nil
+      raise_if_sealed!(:machine_id)
+
+      @machine_id           = value.nil? ? nil : checked_machine_id(value)
+      @machine_id_value     = nil
+      @machine_id_value_pid = nil
     end
 
     def epoch=(value)
+      raise_if_sealed!(:epoch)
+
       @epoch    = value
       @epoch_ms = nil
     end
 
-    def machine_id_value
-      return @machine_id_value if @machine_id_value && @machine_id_value_pid == Process.pid
+    def seal!
+      @sealed = true
+    end
 
-      @machine_id_value_pid = Process.pid
-      @machine_id_value     = resolve_machine_id
+    def machine_id_value
+      if @machine_id_value_pid != Process.pid
+        @machine_id_value     = resolve_machine_id
+        @machine_id_value_pid = Process.pid
+      end
+
+      @machine_id_value
     end
 
     def epoch_ms
@@ -57,7 +69,7 @@ module Snowflaked
     # Resolution order: explicit config, then env vars, then an auto fallback.
     # Explicit and env values are range-checked; the fallback is always valid.
     def resolve_machine_id
-      return checked_machine_id(@machine_id) if @machine_id
+      return @machine_id unless @machine_id.nil?
 
       env = ENV["SNOWFLAKED_MACHINE_ID"] || ENV.fetch("MACHINE_ID", nil)
       return checked_machine_id(env) if env
@@ -74,6 +86,12 @@ module Snowflaked
 
       raise ConfigurationError, "machine_id must be an integer between 0 and #{MAX_MACHINE_ID}, got #{value.inspect}"
     end
+
+    def raise_if_sealed!(attribute)
+      return unless @sealed
+
+      raise ConfigurationError, "#{attribute} cannot be changed after Snowflaked has been configured"
+    end
   end
 
   class << self
@@ -85,13 +103,12 @@ module Snowflaked
       yield(configuration) if block_given?
 
       ensure_initialized!
-      ensure_configuration_unchanged!
       configuration
     end
 
     def id
-      config = configuration
-      Native.generate(config.machine_id_value, config.epoch_ms)
+      ensure_initialized!
+      Native.generate
     end
 
     def parse(id)
@@ -126,25 +143,13 @@ module Snowflaked
     private
 
     def ensure_initialized!
-      return if Native.initialized?
+      return if @native_initialized_pid == Process.pid
 
-      Native.init_generator(configuration.machine_id_value, configuration.epoch_ms)
-    end
+      config = configuration
+      config.seal!
 
-    # The Rust generator is built once per process; machine_id and epoch are
-    # locked in at that point. If either changed afterward, Ruby and Rust would
-    # disagree, so fail loudly instead of silently using the stale generator.
-    def ensure_configuration_unchanged!
-      return unless Native.initialized?
-
-      if Native.configured_machine_id != configuration.machine_id_value
-        raise ConfigurationError,
-              "machine_id cannot be changed after the first ID is generated"
-      end
-
-      return if Native.configured_epoch_ms == (configuration.epoch_ms || 0)
-
-      raise ConfigurationError, "epoch cannot be changed after the first ID is generated"
+      Native.init_generator(config.machine_id_value, config.epoch_ms)
+      @native_initialized_pid = Process.pid
     end
   end
 end

--- a/lib/snowflaked.rb
+++ b/lib/snowflaked.rb
@@ -85,16 +85,7 @@ module Snowflaked
       yield(configuration) if block_given?
 
       ensure_initialized!
-
-      # The Rust generator is built once per process. If machine_id changed
-      # after the first ID was generated, Ruby and Rust would disagree, so
-      # fail loudly here instead of silently using the stale generator.
-      configured = Native.configured_machine_id
-      if configured && configured != configuration.machine_id_value
-        raise ConfigurationError,
-              "machine_id cannot be changed after the first ID is generated (currently #{configured})"
-      end
-
+      ensure_configuration_unchanged!
       configuration
     end
 
@@ -138,6 +129,22 @@ module Snowflaked
       return if Native.initialized?
 
       Native.init_generator(configuration.machine_id_value, configuration.epoch_ms)
+    end
+
+    # The Rust generator is built once per process; machine_id and epoch are
+    # locked in at that point. If either changed afterward, Ruby and Rust would
+    # disagree, so fail loudly instead of silently using the stale generator.
+    def ensure_configuration_unchanged!
+      return unless Native.initialized?
+
+      if Native.configured_machine_id != configuration.machine_id_value
+        raise ConfigurationError,
+              "machine_id cannot be changed after the first ID is generated"
+      end
+
+      return if Native.configured_epoch_ms == (configuration.epoch_ms || 0)
+
+      raise ConfigurationError, "epoch cannot be changed after the first ID is generated"
     end
   end
 end

--- a/sig/snowflaked.rbs
+++ b/sig/snowflaked.rbs
@@ -35,4 +35,5 @@ module Snowflaked
   private
 
   def self.ensure_initialized!: () -> nil
+  def self.ensure_configuration_unchanged!: () -> void
 end

--- a/sig/snowflaked.rbs
+++ b/sig/snowflaked.rbs
@@ -19,9 +19,8 @@ module Snowflaked
 
     private
 
-    def default_machine_id: () -> Integer
-    def env_machine_id: () -> Integer?
-    def hostname_pid_hash: () -> Integer
+    def resolve_machine_id: () -> Integer
+    def checked_machine_id: (untyped value) -> Integer
   end
 
   def self.configuration: () -> Configuration

--- a/sig/snowflaked.rbs
+++ b/sig/snowflaked.rbs
@@ -14,6 +14,7 @@ module Snowflaked
     attr_accessor epoch: Time?
 
     def initialize: () -> void
+    def seal!: () -> true
     def machine_id_value: () -> Integer
     def epoch_ms: () -> Integer?
 
@@ -35,5 +36,4 @@ module Snowflaked
   private
 
   def self.ensure_initialized!: () -> nil
-  def self.ensure_configuration_unchanged!: () -> void
 end

--- a/snowflaked.gemspec
+++ b/snowflaked.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
     "lib/**/*",
     "ext/**/*",
     "Cargo.toml",
+    "Cargo.lock",
     "LICENSE.txt",
     "README.md"
   ]

--- a/test/test_snowflaked.rb
+++ b/test/test_snowflaked.rb
@@ -246,6 +246,15 @@ class TestSnowflaked < ActiveSupport::TestCase
     Snowflaked.configuration.machine_id = original
   end
 
+  def test_reconfiguring_epoch_raises
+    original = Snowflaked.configuration.epoch
+    Snowflaked.configuration.epoch = Time.utc(2020, 1, 1)
+
+    assert_raises(Snowflaked::ConfigurationError) { Snowflaked.configure }
+  ensure
+    Snowflaked.configuration.epoch = original
+  end
+
   private
 
   def fork_and_collect(&)

--- a/test/test_snowflaked.rb
+++ b/test/test_snowflaked.rb
@@ -191,6 +191,61 @@ class TestSnowflaked < ActiveSupport::TestCase
                                                    "Set a default epoch of at least 2024-01-01 to push overflow to ~2093."
   end
 
+  def test_ids_are_non_negative
+    1000.times { assert_operator Snowflaked.id, :>=, 0 }
+  end
+
+  def test_machine_id_value_computed_once_per_process
+    config = Snowflaked::Configuration.new
+    calls = []
+    Socket.singleton_class.prepend(Module.new do
+      define_method(:gethostname) do
+        calls << true
+        super()
+      end
+    end)
+
+    3.times { config.machine_id_value }
+
+    assert_equal 1, calls.size, "machine_id_value must memoize and not call gethostname on every access"
+  end
+
+  def test_explicit_out_of_range_machine_id_raises
+    config = Snowflaked::Configuration.new
+    config.machine_id = Snowflaked::MAX_MACHINE_ID + 1
+
+    assert_raises(Snowflaked::ConfigurationError) { config.machine_id_value }
+  end
+
+  def test_non_integer_env_machine_id_raises
+    config = Snowflaked::Configuration.new
+
+    ENV["SNOWFLAKED_MACHINE_ID"] = "not-a-number"
+    assert_raises(Snowflaked::ConfigurationError) { config.machine_id_value }
+  ensure
+    ENV.delete("SNOWFLAKED_MACHINE_ID")
+  end
+
+  def test_timestamp_falls_back_to_utc_without_time_zone
+    id = Snowflaked.id
+
+    Time.use_zone(nil) do
+      timestamp = Snowflaked.timestamp(id)
+
+      assert_kind_of Time, timestamp
+      assert_predicate timestamp, :utc?
+    end
+  end
+
+  def test_reconfiguring_machine_id_raises
+    original = Snowflaked.configuration.machine_id
+    Snowflaked.configuration.machine_id = (Snowflaked::Native.configured_machine_id + 1) % (Snowflaked::MAX_MACHINE_ID + 1)
+
+    assert_raises(Snowflaked::ConfigurationError) { Snowflaked.configure }
+  ensure
+    Snowflaked.configuration.machine_id = original
+  end
+
   private
 
   def fork_and_collect(&)

--- a/test/test_snowflaked.rb
+++ b/test/test_snowflaked.rb
@@ -172,6 +172,19 @@ class TestSnowflaked < ActiveSupport::TestCase
     end
   end
 
+  def test_first_generation_after_fork_is_thread_safe
+    child_ids, = fork_and_collect do
+      threads = Array.new(20) do
+        Thread.new { Array.new(100) { Snowflaked.id } }
+      end
+
+      [threads.flat_map(&:value)]
+    end
+
+    assert_equal 2000, child_ids.size
+    assert_equal 2000, child_ids.uniq.size
+  end
+
   def test_epoch_ms_returns_exact_milliseconds_without_float_rounding
     epoch = Time.at(Rational(1_704_067_200_002, 1000)).utc
     config = Snowflaked::Configuration.new
@@ -197,24 +210,45 @@ class TestSnowflaked < ActiveSupport::TestCase
 
   def test_machine_id_value_computed_once_per_process
     config = Snowflaked::Configuration.new
-    calls = []
-    Socket.singleton_class.prepend(Module.new do
-      define_method(:gethostname) do
-        calls << true
-        super()
-      end
-    end)
+    calls = 0
+
+    config.define_singleton_method(:resolve_machine_id) do
+      calls += 1
+      123
+    end
 
     3.times { config.machine_id_value }
 
-    assert_equal 1, calls.size, "machine_id_value must memoize and not call gethostname on every access"
+    assert_equal 1, calls, "machine_id_value must memoize and not resolve on every access"
+  end
+
+  def test_machine_id_value_refreshes_value_before_pid
+    old_pid = Process.pid - 1
+    config = configuration_with_stale_machine_id(old_pid)
+    pid_seen_while_resolving = nil
+
+    config.define_singleton_method(:resolve_machine_id) do
+      pid_seen_while_resolving = instance_variable_get(:@machine_id_value_pid)
+      456
+    end
+
+    assert_equal 456, config.machine_id_value
+    assert_equal old_pid, pid_seen_while_resolving
+    assert_equal Process.pid, config.instance_variable_get(:@machine_id_value_pid)
+  end
+
+  def test_machine_id_writer_clears_cached_process_value
+    config = Snowflaked::Configuration.new
+    config.machine_id_value
+    config.machine_id = 456
+
+    assert_equal 456, config.machine_id_value
   end
 
   def test_explicit_out_of_range_machine_id_raises
     config = Snowflaked::Configuration.new
-    config.machine_id = Snowflaked::MAX_MACHINE_ID + 1
 
-    assert_raises(Snowflaked::ConfigurationError) { config.machine_id_value }
+    assert_raises(Snowflaked::ConfigurationError) { config.machine_id = Snowflaked::MAX_MACHINE_ID + 1 }
   end
 
   def test_non_integer_env_machine_id_raises
@@ -237,35 +271,53 @@ class TestSnowflaked < ActiveSupport::TestCase
     end
   end
 
-  def test_reconfiguring_machine_id_raises
-    original = Snowflaked.configuration.machine_id
-    Snowflaked.configuration.machine_id = (Snowflaked::Native.configured_machine_id + 1) % (Snowflaked::MAX_MACHINE_ID + 1)
+  def test_machine_id_cannot_change_after_configuration_is_sealed
+    config = Snowflaked::Configuration.new
+    config.machine_id = 123
+    config.seal!
 
-    assert_raises(Snowflaked::ConfigurationError) { Snowflaked.configure }
-  ensure
-    Snowflaked.configuration.machine_id = original
+    assert_raises(Snowflaked::ConfigurationError) { config.machine_id = 456 }
+    assert_equal 123, config.machine_id
   end
 
-  def test_reconfiguring_epoch_raises
-    original = Snowflaked.configuration.epoch
-    Snowflaked.configuration.epoch = Time.utc(2020, 1, 1)
+  def test_epoch_cannot_change_after_configuration_is_sealed
+    epoch = Time.utc(2024, 1, 1)
+    config = Snowflaked::Configuration.new
+    config.epoch = epoch
+    config.seal!
 
-    assert_raises(Snowflaked::ConfigurationError) { Snowflaked.configure }
-  ensure
-    Snowflaked.configuration.epoch = original
+    assert_raises(Snowflaked::ConfigurationError) { config.epoch = Time.utc(2025, 1, 1) }
+    assert_equal epoch, config.epoch
   end
 
   private
 
-  def fork_and_collect(&)
-    IO.pipe do |read_io, write_io|
-      pid = fork do
-        read_io.close
-        write_io.puts(JSON.dump(yield))
-        exit!(0)
-      end
-      write_io.close
-      JSON.parse(read_io.read).tap { Process.wait(pid) }
+  def configuration_with_stale_machine_id(old_pid)
+    Snowflaked::Configuration.new.tap do |config|
+      config.instance_variable_set(:@machine_id_value, 123)
+      config.instance_variable_set(:@machine_id_value_pid, old_pid)
     end
+  end
+
+  def fork_and_collect(&block)
+    IO.pipe do |read_io, write_io|
+      pid = fork { write_child_payload(read_io, write_io, block) }
+      write_io.close
+      parse_child_payload(read_io.read, pid)
+    end
+  end
+
+  def write_child_payload(read_io, write_io, block)
+    read_io.close
+    write_io.puts(JSON.dump(block.call))
+    exit!(0)
+  end
+
+  def parse_child_payload(payload, pid)
+    _, status = Process.wait2(pid)
+
+    assert_predicate status, :success?, "forked child exited unsuccessfully"
+
+    JSON.parse(payload)
   end
 end


### PR DESCRIPTION
Ruby now owns configuration resolution and locks it before native initialization. Rust receives the resolved machine ID and epoch once per process, stores only the generator state it needs, and `Snowflaked.id` now calls zero-argument native generation on the hot path.

This keeps Puma fork behavior explicit: Ruby reinitializes native state when the PID changes, and Rust refuses to use parent-process state in a child. The branch also keeps the reliability fixes for backward-clock panics, signed BIGINT-safe IDs, exact epoch math, machine ID validation, and the `Time.zone` fallback outside Rails.

The tests cover forked worker generation, first generation after fork with concurrent threads, configuration sealing, machine ID validation, memoization, and timestamp behavior. Verified with `bundle exec rake compile`, `bundle exec rake test`, `env RUBOCOP_CACHE_ROOT=tmp/rubocop_cache bundle exec rubocop --format simple`, `cargo fmt --check`, and `cargo test`.
